### PR TITLE
Fix handling of MACH_NOTIFY_SEND_ONCE notifications

### DIFF
--- a/tests/sender.rs
+++ b/tests/sender.rs
@@ -57,3 +57,45 @@ fn send_with_no_reply() {
         }
     });
 }
+
+#[test]
+fn send_with_reply_but_ignored() {
+    let server_name = TEST_ID.with(|id| {
+        let id = core::ptr::addr_of!(id) as usize as u64;
+        utils::server_name(id)
+    });
+
+    let mut server = Server::register(&server_name).unwrap();
+
+    let (sender_done, mut wait_for_sender) = tokio::sync::mpsc::unbounded_channel();
+    std::thread::spawn(move || {
+        let mut client = Client::connect(&server_name).unwrap();
+        let err = client.send_with_reply(TEST_MSG).unwrap_err();
+        sender_done.send(err).unwrap();
+    });
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let mut incoming_messages = std::pin::pin!(server.listen());
+
+        let mut received = false;
+
+        loop {
+            tokio::select! {
+                new_msg = incoming_messages.next() => {
+                    let new_msg = new_msg.unwrap().unwrap();
+                    assert_eq!(new_msg.data, TEST_MSG, "server message corrupt");
+                    assert_eq!(new_msg.msg_id, 0, "unexpected msg_id");
+                    received = true;
+                }
+
+                sender_done = wait_for_sender.recv(), if received => {
+                    assert_eq!(sender_done, Some(Error::NoReply));
+                    break;
+                },
+            }
+        }
+    });
+}


### PR DESCRIPTION
This PR fixes an oversight I made that forgot to handle the case where a sender requests a reply but the server immediately deallocates the reply port instead of using that send-once right. In these cases, per the documentation, the kernel will pick up the task of guaranteeing the single message by sending the receiver call a `mach_send_once_notification_t`. 

Previously this wasn't being accounted for, resulting in accidentally interpreting the `mach_msg_format_0_trailer_t` trailer size bytes as part of the inline data length, which caused an integer underflow/slice length panic in the client process.